### PR TITLE
Update conditional check to allow build on arm

### DIFF
--- a/inotify-cxx.h
+++ b/inotify-cxx.h
@@ -36,7 +36,7 @@
 #include <sys/inotify.h>
 
 // Use this if syscalls not defined
-#ifndef __NR_inotify_init
+#if not defined(__NR_inotify_init) && not defined(__NR_inotify_init1)
 #include <sys/inotify-syscalls.h>
 #endif // __NR_inotify_init
 


### PR DESCRIPTION
Looks like the `inotify_init` syscall is deprecated and doesn't exist at all on arm64 (and probablly
won't exist on other architectures that are regarded as completely new either), according to [this bug report](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=767758)

I patched this fork copying the line from a [newer version](https://github.com/ar-/incron/blob/master/inotify-cxx.h#L39) of it.

I was able to compile after this change.